### PR TITLE
chore(build): add helm lint workflow

### DIFF
--- a/.act/pr_event.json
+++ b/.act/pr_event.json
@@ -1,0 +1,5 @@
+{
+  "repository": {
+    "default_branch": "main"
+  }
+}

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,0 +1,56 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+name: Lint Helm Charts (PR + dispatch)
+
+on:
+  pull_request:
+    branches: main
+    paths:
+      - 'charts/**'
+  workflow_dispatch:
+
+jobs:
+  lint-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.11.2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (lint)
+        run: |
+          ct lint \
+            --validate-maintainers=false \
+            --check-version-increment=false \
+            --target-branch ${{ github.event.repository.default_branch }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# e2e-testing
+# Eclipse Tractus-X e2e-testing
+
+The repository is the homebase for all e2e test automation efforts at Eclipse Tractus-X.
+It contains umbrella Helm Chart to deploy a sandbox Catena-X dataspace based on the Tractus-X OSS components, as well as
+automated tests and workflows to verify the end-to-end use cases and the compatibility of the OSS components and versions.
+
+## Testing GitHub workflows locally
+
+If you want to try out your new or improved GitHub workflow locally, before pushing, you can try to use
+[act](https://github.com/nektos/act). Follow the official [installation instructions](https://github.com/nektos/act#installation)
+for your OS/package manager to set it up on your machine.
+
+There is also plenty of documentation on how to use act and simulate events, that would trigger workflow runs on GitHub.
+Some workflows might run into issues, when running them locally. This might be caused by missing values for
+`${{ github.event }}` references. To fix this, you can provide your own [event](https://github.com/nektos/act#installation)
+as `.json` file. There are already examples present in the [/.act](.act) directory.
+
+An local example run via `act` could look like the following: `act -e .act/pr_event.json pull_request`


### PR DESCRIPTION
# Description

This PR adds a workflow, that will lint the Helm Charts contained in this repository. 
Triggers are set to `pull_request` to main and `workflow_dispatch`.
Linting will always be executed, regardless of whether the Chart has changed or not.
To make the Check more resilient and forgiving, the maintainer and version-increment checks are disabled