### PR TITLE
feat(build): add initial workflow for helm testing

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,70 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+name: Helm Test (dispatch)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-charts:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Executing the Jobs sequentially to avoid race conditions for ct and kubectl context
+        max-parallel: 1
+        # This will be used as node_image tag
+        # see https://hub.docker.com/r/kindest/node/tags for available tags (tags always pinned to bugfix level)
+        kind_node_version: ["v1.24.12"] #, "v1.25.8", "v1.26.3"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.11.2
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+        with:
+          node_image: ${{ format('kindest/node:{0}', matrix.kind_node_version) }}
+          # Create clusters with separate names, so there are no clashes on the worker
+          cluster_name: ${{ format('chart-testing-{0}', matrix.kind_node_version) }}
+
+      - name: Run chart-testing (install)
+        # The current umbrella chart requires a dedicated dependency build for tractusx-connector sub chart
+        # Chain kubectl + ct calls to avoid race condition (max-parallel setting should also prevent that)
+        # ct install '--all' charts, to skip changed charts detection and automatically include new charts in this repo
+        run: |
+          cd charts/umbrella/charts/tractusx-connector
+          helm dependency build
+          cd ${{ env.GITHUB_WORKSPACE }}
+          kubectl config use-context ${{ format('kind-chart-testing-{0}', matrix.kind_node_version) }}
+          ct install --all --chart-dirs charts/


### PR DESCRIPTION
# Description

This PR adds an initial workflow runs helm test with [chart-testing-action](https://github.com/helm/chart-testing-action) and `ct install`. To install the chart, a kind cluster using [kind-action](https://github.com/helm/kind-action).

The workflow itself is already prepared to run a matrix build to test the chart und multiple different kubernetes  versions.
The strategy is configured to only allow 1 parallel build to avoid race conditions of parallel `kubectl` commands (potential context issues).

fixes #3 