### PR TITLE
feat: add hack script for charts/umbrella recursive dependencies

### DIFF
--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -12,11 +12,10 @@ Assuming you have a running cluster and your `kubectl` context is set to that cl
 the Chart as `lab` release.
 
 ```shell
-# Running from the root of this repository
+# Download (recursive chart dependencies) with hack script
+hack/helm-dependencies.bash
+
 cd charts/umbrella
-helm dependency build
-# The connector subchart has additional dependencies, that have to be built
-helm dependency build charts/tractusx-connector
 
 helm install lab . --namespace lab --create-namespace
 ```

--- a/hack/helm-dependencies.bash
+++ b/hack/helm-dependencies.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This hack script will download all chart/umbrella dependency charts.
+# (including recursive dependencies)
+
+find charts/umbrella -name Chart.yaml -print | \
+  sed s/Chart.yaml//g | \
+  awk -F"/" '{print NF $0}' | \
+  sort -nr | \
+  sed 's/^.//' | \
+  xargs -n1 helm dependency update --skip-refresh


### PR DESCRIPTION
Currently the charts/umbrella Helm chart requires download not only from its dependencies but also their dependency (recursive).

This PR adds a hack-script for a simpler download of these recursive dependencies.

closes #7