### PR TITLE
chore(helm): use url instead of address value key for certs chart

### DIFF
--- a/charts/umbrella/charts/certs/templates/job-daps.yaml
+++ b/charts/umbrella/charts/certs/templates/job-daps.yaml
@@ -34,7 +34,7 @@ spec:
         #   - "3600"
         env:
           - name: DAPS_ADDR
-            value: {{ tpl .Values.daps.address . }}
+            value: {{ tpl .Values.daps.url . }}
 
           - name: DAPS_AUTH_CLIENT_ID
             value: {{ .Values.daps.auth.clientId }}

--- a/charts/umbrella/charts/certs/templates/job-vault.yaml
+++ b/charts/umbrella/charts/certs/templates/job-vault.yaml
@@ -39,7 +39,7 @@ spec:
         #   - "3600"
         env:
           - name: VAULT_ADDR
-            value: {{ tpl .Values.vault.address . }}
+            value: {{ tpl .Values.vault.url . }}
           - name: VAULT_TOKEN
             value: {{ .Values.vault.token }}
 

--- a/charts/umbrella/charts/certs/values.yaml
+++ b/charts/umbrella/charts/certs/values.yaml
@@ -18,7 +18,7 @@
 # #############################################################################
 ---
 daps:
-  address: http://daps:4567
+  url: http://daps:4567
 
   auth:
     clientId: ""
@@ -28,7 +28,7 @@ daps:
     clientId: ""
 
 vault:
-  address: http://vault:8200
+  url: http://vault:8200
 
   daps:
     privateKey: "daps-privatekey"

--- a/charts/umbrella/charts/certs/values.yaml
+++ b/charts/umbrella/charts/certs/values.yaml
@@ -18,7 +18,7 @@
 # #############################################################################
 ---
 daps:
-  url: http://daps:4567
+  url: http://{{ .Release.Name }}-daps:4567
 
   auth:
     clientId: ""
@@ -28,7 +28,7 @@ daps:
     clientId: ""
 
 vault:
-  url: http://vault:8200
+  url: http://{{ .Release.Name }}-vault:8200
 
   daps:
     privateKey: "daps-privatekey"

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -68,7 +68,7 @@ global:
 
 certsconsumer:
   daps:
-    address: *dapsUrl
+    url: *dapsUrl
     auth:
       clientId: *dapsClientId
       clientSecret: *dapsClientSecret
@@ -76,7 +76,7 @@ certsconsumer:
       clientId: *edcConsumerDapsClientId
 
   vault:
-    address: *vaultUrl
+    url: *vaultUrl
     daps:
       privateKey: *edcConsumerVaultDapsPrivateKey
       publicKey: *edcConsumerVaultDapsPublicKey
@@ -88,7 +88,7 @@ certsconsumer:
 
 certsprovider:
   daps:
-    address: *dapsUrl
+    url: *dapsUrl
     auth:
       clientId: *dapsClientId
       clientSecret: *dapsClientSecret
@@ -96,7 +96,7 @@ certsprovider:
       clientId: *edcProviderDapsClientId
 
   vault:
-    address: *vaultUrl  
+    url: *vaultUrl
     daps:
       privateKey: *edcProviderVaultDapsPrivateKey
       publicKey: *edcProviderVaultDapsPublicKey


### PR DESCRIPTION
In other tx [charts](https://github.com/eclipse-tractusx/tractusx-edc/blob/c5b61db65413d130b6f521b76cf32285e65a6aad/charts/tractusx-connector/values.yaml#L530-L532) the name of the daps and vault is url not address.
This change will change the certs dependency chart to have the same structure.

Also the `.Release.Name` will be included in the url in the default values.
This will currently automatically be overwritten by the umbrella chart in the same way:

https://github.com/eclipse-tractusx/e2e-testing/blob/fcabc2a2e938951c0a9e2de81833c5401d4c23bf/charts/umbrella/values.yaml#L65-L66

https://github.com/eclipse-tractusx/e2e-testing/blob/fcabc2a2e938951c0a9e2de81833c5401d4c23bf/charts/umbrella/values.yaml#L78-L79

This change will affect both daps and vault.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))