### PR TITLE
chore(helm): set certs dep-chart required values

### DIFF
--- a/charts/umbrella/charts/certs/templates/job-daps.yaml
+++ b/charts/umbrella/charts/certs/templates/job-daps.yaml
@@ -37,13 +37,13 @@ spec:
             value: {{ tpl .Values.daps.address . }}
 
           - name: DAPS_AUTH_CLIENT_ID
-            value: {{ .Values.daps.auth.clientId }}
+            value: {{ .Values.daps.auth.clientId | required ".Values.daps.auth.clientId is required" }}
 
           - name: DAPS_AUTH_CLIENT_SECRET
-            value: {{ .Values.daps.auth.clientSecret }}
+            value: {{ .Values.daps.auth.clientSecret | required ".Values.daps.auth.clientSecret is required" }}
 
           - name: DAPS_EDC_CLIENT_ID
-            value: {{ .Values.daps.edc.clientId }}
+            value: {{ .Values.daps.edc.clientId | required ".Values.daps.edc.clientId is required" }}
 
           - name: DAPS_PUBLICKEY_VALUE
             valueFrom:


### PR DESCRIPTION
Some fields of the `certs` dependency chart are mandatory.
This PR will add the required check for those:

- `.Values.daps.auth.clientId`
- `.Values.daps.auth.clientSecret`
- `.Values.daps.edc.clientId`

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))