### PR TITLE
chore(helm): add url to connecting instance for certs chart

### DIFF
--- a/charts/umbrella/charts/certs/templates/configmap-daps.yaml
+++ b/charts/umbrella/charts/certs/templates/configmap-daps.yaml
@@ -26,7 +26,7 @@ data:
     #!/bin/sh
     set -e
 
-    echo "Transfering certificates to DAPS..."
+    echo "Transfering certificates to DAPS (${DAPS_ADDR})..."
     sleep 5
 
     echo "Check DAPS..."

--- a/charts/umbrella/charts/certs/templates/configmap-vaultscript.yaml
+++ b/charts/umbrella/charts/certs/templates/configmap-vaultscript.yaml
@@ -26,7 +26,7 @@ data:
     #!/bin/sh
     set -e
 
-    echo "Transfering certificates to vault..."
+    echo "Transfering certificates to vault (${VAULT_ADDR})..."
     sleep 5
 
 


### PR DESCRIPTION
Currently there is no information in the job log of the `certs` dependency chart to which daps / vault the connection is established.

This PR will add the address to the configmap thus the address will added in the pod log.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))