### PR TITLE
chore: add kyverno validation workflow

### DIFF
--- a/.github/kyverno-policies/require-run-as-nonroot.yaml
+++ b/.github/kyverno-policies/require-run-as-nonroot.yaml
@@ -1,0 +1,54 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-run-as-nonroot
+  annotations:
+    policies.kyverno.io/title: Require runAsNonRoot
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      Containers must be required to run as non-root users. This policy ensures
+      `runAsNonRoot` is set to `true`. A known issue prevents a policy such as this
+      using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
+spec:
+  validationFailureAction: audit
+  background: true
+  rules:
+    - name: run-as-non-root
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot
+          must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot,
+          spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot
+          must be set to `true`.
+        anyPattern:
+        - spec:
+            securityContext:
+              runAsNonRoot: "true"
+            =(ephemeralContainers):
+            - =(securityContext):
+                =(runAsNonRoot): "true"
+            =(initContainers):
+            - =(securityContext):
+                =(runAsNonRoot): "true"
+            containers:
+            - =(securityContext):
+                =(runAsNonRoot): "true"
+        - spec:
+            =(ephemeralContainers):
+            - securityContext:
+                runAsNonRoot: "true"
+            =(initContainers):
+            - securityContext:
+                runAsNonRoot: "true"
+            containers:
+            - securityContext:
+                runAsNonRoot: "true"

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -72,6 +72,10 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
+      - name: Download chart dependencies (recursive)
+        shell: bash
+        run: hack/helm-dependencies.bash
+
       - name: Create Helm template
         run: |
             helm template chart-template ${{ matrix.chart }}/ > ${{ matrix.chart }}/chart-template.yaml

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -1,0 +1,87 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+name: Test Kyverno Policies
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+  workflow_dispatch:
+
+jobs:
+  list-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: "${{ steps.list-changed.outputs.changed }}"
+      charts: "${{ steps.list-changed.outputs.charts }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: List changes
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch main)
+          arr=(`echo $changed`)
+          json=$(echo "${arr[@]}" | jq -ncR 'inputs | split(" ")')
+          echo "charts=$json" >> $GITHUB_OUTPUT
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+
+  kyverno-validate:
+    runs-on: ubuntu-latest
+    needs: [list-changed]
+    if: ${{ needs.list-changed.outputs.changed == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        chart:
+          - ${{ fromJson(needs.list-changed.outputs.charts) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/checkout@v3
+        name: Checkout kyverno-policies
+        with:
+          repository: kyverno/policies
+          ref: main
+          path: kyverno-policies
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Test against Kyverno policies
+        uses: ckotzbauer/kyverno-test-action@v2
+        with:
+          chart-dir: "${{ matrix.chart }}"
+          value-files: |
+            ${{ matrix.chart }}/values.yaml
+          policy-files: |
+            kyverno-policies/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml

--- a/.github/workflows/kyverno.yaml
+++ b/.github/workflows/kyverno.yaml
@@ -27,6 +27,9 @@ on:
       - 'charts/**'
   workflow_dispatch:
 
+env:
+  VERSION: v1.10.1
+
 jobs:
   list-changed:
     runs-on: ubuntu-latest
@@ -53,7 +56,6 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-
   kyverno-validate:
     runs-on: ubuntu-latest
     needs: [list-changed]
@@ -64,24 +66,21 @@ jobs:
         chart:
           - ${{ fromJson(needs.list-changed.outputs.charts) }}
     steps:
-      - name: Checkout
+      - name: Checkout repo
         uses: actions/checkout@v3
-
-      - uses: actions/checkout@v3
-        name: Checkout kyverno-policies
-        with:
-          repository: kyverno/policies
-          ref: main
-          path: kyverno-policies
 
       - name: Install Helm
         uses: azure/setup-helm@v3
 
-      - name: Test against Kyverno policies
-        uses: ckotzbauer/kyverno-test-action@v2
-        with:
-          chart-dir: "${{ matrix.chart }}"
-          value-files: |
-            ${{ matrix.chart }}/values.yaml
-          policy-files: |
-            kyverno-policies/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+      - name: Create Helm template
+        run: |
+            helm template chart-template ${{ matrix.chart }}/ > ${{ matrix.chart }}/chart-template.yaml
+
+      - name: Download Kyverno CLI
+        run: |
+          curl -sLO https://github.com/kyverno/kyverno/releases/download/${{ env.VERSION }}/kyverno-cli_${{ env.VERSION }}_linux_x86_64.tar.gz
+          tar -xf kyverno-cli_${{ env.VERSION }}_linux_x86_64.tar.gz
+          ${GITHUB_WORKSPACE}/kyverno version          
+
+      - name: Test new resources against existing policies
+        run: ${GITHUB_WORKSPACE}/kyverno apply .github/kyverno-policies/require-run-as-nonroot.yaml -r ${{ matrix.chart }}/chart-template.yaml


### PR DESCRIPTION
### Description
Add Kyverno validation workflow

A GitHub workflow to run on pull requests when a chart is changed in the repository. Kyverno will validate different aspects of the chart. Currently the single validation enabled is that pods (and other resources managing pods) have the `runAsNonRoot` security context enabled. Chart testing is running first to detect if any of the charts are changed. Then it dispatches as many Kyverno validation jobs in a matrix as needed for every changed chart.

Fixes #12 

### Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
