### PR TITLE
chore(psql): add securityContext to run as nonRoot

### DIFF
--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -173,9 +173,9 @@ edcconsumer:
       podSecurityContext:
         enabled: true
         runAsNonRoot: true
-        runAsGroup: 65534 # nogroup
+        runAsGroup: 65534
         runAsUser: 1001
-        fsGroup: 65534 # nogroup
+        fsGroup: 65534
 
   vault:
     hashicorp:
@@ -240,9 +240,9 @@ edcprovider:
       podSecurityContext:
         enabled: true
         runAsNonRoot: true
-        runAsGroup: 65534 # nogroup
+        runAsGroup: 65534
         runAsUser: 1001
-        fsGroup: 65534 # nogroup
+        fsGroup: 65534
 
   vault:
     hashicorp:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -169,6 +169,14 @@ edcconsumer:
       username: psql-consumer-user
       password: psql-consumer-password
 
+    primary:
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        runAsGroup: 65534 # nogroup
+        runAsUser: 1001
+        fsGroup: 65534 # nogroup
+
   vault:
     hashicorp:
       token: *edcVaultToken
@@ -227,6 +235,14 @@ edcprovider:
     auth:
       username: psql-provider-user
       password: psql-provider-password
+
+    primary:
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        runAsGroup: 65534 # nogroup
+        runAsUser: 1001
+        fsGroup: 65534 # nogroup
 
   vault:
     hashicorp:


### PR DESCRIPTION
## Description

Run the psql for consumer and provider with securityontext as nonRoot container.

### Additional information

- related to #28 - will decrease kyverno nonRoot findings

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))