### PR TITLE
fix: replace tx-c-legacy sub-dependency omejdn with daps-server 1.8.0

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -38,6 +38,11 @@ dependencies:
     name: certs
     version: 0.1.0
 
+  - alias: daps
+    name: daps-server
+    version: 1.8.0
+    repository: https://eclipse-tractusx.github.io/charts/dev
+
   # edc consumer
   - alias: edcconsumer
     name: tractusx-connector-legacy

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -30,7 +30,6 @@ global:
 
 
   daps:
-    # url: &dapsUrl "http://{{ .Release.Name }}-daps:4567"
     auth:
       # management login credentials for daps-server (username)
       clientId: &dapsClientId admin
@@ -115,11 +114,28 @@ certsprovider:
       privateKey: *edcProviderVaultTransferPrivateKey
       publicKey: *edcProviderVaultTransferPublicKey
 
+daps:
+  clientId: *edcConsumerDapsClientId
+
+  daps:
+    secret:
+      clientId: *dapsClientId
+      clientSecret: *dapsClientSecret
+
+  networkPolicy:
+    enabled: *netPolEnabled
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+
 edcconsumer:
   nameOverride: edcconsumer
 
   install:
-    daps: true
+    daps: false
     postgresql: true
     vault: true
 
@@ -138,22 +154,6 @@ edcconsumer:
 
   daps:
     clientId: *edcConsumerDapsClientId
-
-    daps:
-      secret:
-        clientId: *dapsClientId
-        clientSecret: *dapsClientSecret
-
-    image:
-      repository: ghcr.io/fraunhofer-aisec/omejdn-server
-
-    # podSecurityContext:
-    #   fsGroup: 1000
-    #   runAsNonRoot: true
-    #   runAsUser: 1000
-    #   runAsGroup: 1000
-    # persistence:
-    #   accessMode: "ReadWriteOnce"
 
   dataplane:
     image:


### PR DESCRIPTION
## Description

The included dependency subchart in the tractusx-connector-legacy chart in v0.5.0-rc1 does not work as intended ([configuration](https://github.com/eclipse-tractusx/tractusx-edc/blob/0.5.0-rc1/charts/tractusx-connector-legacy/subcharts/omejdn/templates/configmap.yaml) of daps not correctly).
Therefore the latest daps-server chart will be configured directly to the umbrella chart.

This change then will resolve in a working infrastructure for EDC v0.4.1.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))