### PR TITLE
chore: add networkPolicy enabled for vault dependency

### DIFF
--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -191,6 +191,9 @@ edcconsumer:
       dev:
         devRootToken: *edcVaultToken
 
+      networkPolicy:
+        enabled: *netPolEnabled
+
     secretNames:
       dapsPrivateKey: *edcConsumerVaultDapsPrivateKey
       dapsPublicKey: *edcConsumerVaultDapsPublicKey


### PR DESCRIPTION
Enable networkPolicy for vault dependency for the umbrella chart.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))