### PR TITLE
feat: add initial setup for portal and cx-iam

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -48,3 +48,18 @@ dependencies:
     name: tractusx-connector-legacy
     version: 0.5.0-rc1
     repository: https://eclipse-tractusx.github.io/charts/dev
+
+  # portal
+  - condition: portal.enabled
+    name: portal
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: 1.6.0
+  # cx-iam
+  - condition: centralidp.enabled
+    name: centralidp
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: 1.2.0
+  - condition: sharedidp.enabled
+    name: sharedidp
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: 1.2.0

--- a/charts/umbrella/templates/_helpers.tpl
+++ b/charts/umbrella/templates/_helpers.tpl
@@ -81,3 +81,33 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Postgresql is a dependency of a dependency, which resulted in an empty .Chart.Name..
+Therefore, setting the chart name to the static value for the relevant resources.
+*/}}
+
+{{- define "postgresql.primary.fullname" -}}
+{{- if eq .Values.architecture "replication" }}
+    {{- printf "%s-primary" (include "chart-name-postgresql-dependency" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{- include "chart-name-postgresql-dependency" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.readReplica.fullname" -}}
+{{- printf "%s-read" (include "chart-name-postgresql-dependency" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "chart-name-postgresql-dependency" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "postgresql" .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -271,7 +271,7 @@ edcprovider:
       transferProxyTokenSignerPublicKey: *edcProviderVaultTransferPublicKey
 
 portal:
-  enabled: true
+  enabled: false
   replicaCount: 1
 
 centralidp:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -275,7 +275,7 @@ portal:
   replicaCount: 1
 
 centralidp:
-  enabled: true
+  enabled: false
   keycloak:
     nameOverride: "centralidp"
     replicaCount: 1

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -271,7 +271,7 @@ edcprovider:
       transferProxyTokenSignerPublicKey: *edcProviderVaultTransferPublicKey
 
 portal:
-  enabled: false
+  enabled: true
   replicaCount: 1
 
 centralidp:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -269,3 +269,23 @@ edcprovider:
       transferProxyTokenEncryptionAesKey: *edcProviderVaultTransferEncryptionAesKey
       transferProxyTokenSignerPrivateKey: *edcProviderVaultTransferPrivateKey
       transferProxyTokenSignerPublicKey: *edcProviderVaultTransferPublicKey
+
+portal:
+  enabled: true
+  replicaCount: 1
+
+centralidp:
+  enabled: true
+  keycloak:
+    nameOverride: "centralidp"
+    replicaCount: 1
+    postgresql:
+      nameOverride: "centralidp-postgresql"
+
+sharedidp:
+  enabled: true
+  keycloak:
+    nameOverride: "sharedidp"
+    replicaCount: 1
+    postgresql:
+      nameOverride: "sharedidp-postgresql"


### PR DESCRIPTION
## Description

This PR adds the helm charts from portal and cx-iam (versions from 3.2/23.09 release) to the umbrella chart.
It doesn't contain tests in [this sense](https://helm.sh/docs/helm/helm_test/#helm) and for a proper proper e2e testing functional tests as wells as more config would need to get added, still, for an initial integration in the umbrella helm chart this PR should be sufficient.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
