### PR TITLE
fix: add setup-helm step as required by chart-testing-action

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -56,6 +56,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.12.1
+
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

It states that helm and python must be installed for the [chart-testing-action](https://github.com/helm/chart-testing-action?tab=readme-ov-file#example-workflow).

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
