### PR TITLE
feat: upgrade portal and iam subcharts to 23.12 release

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -17,13 +17,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # #############################################################################
 ---
-name: Helm Checks (Lint, Test, Kyverno policies)
+name: Helm Checks (Lint, Install)
+
 on:
   pull_request:
     paths:
       - 'charts/**'
-    branches:
-      - main
+    # branches:
+    #   - main
   workflow_dispatch:
     inputs:
       node_image:
@@ -154,4 +155,3 @@ jobs:
 #
   #  - name: Test new resources against existing policies
   #    run: kyverno apply .github/kyverno-policies/ -r charts/umbrella-template.yaml
-

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -35,13 +35,13 @@ dependencies:
   - condition: portal.enabled
     name: portal
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.6.0
+    version: 1.7.0
   # cx-iam
   - condition: centralidp.enabled
     name: centralidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.2.0
+    version: 2.0.0
   - condition: sharedidp.enabled
     name: sharedidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.2.0
+    version: 2.0.0


### PR DESCRIPTION
## Description

feat: upgrade portal and iam subcharts to 23.12 release
chore(helm checks): run on every pr and rename workflow

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
